### PR TITLE
delete specific version for gem dependencies

### DIFF
--- a/kickbox.gemspec
+++ b/kickbox.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["lib/**/*"]
 
-  gem.add_dependency "faraday"
-  gem.add_dependency "json"
+  gem.add_dependency "faraday", ">= 0.8.8"
+  gem.add_dependency "json", ">= 1.7.7"
 end


### PR DESCRIPTION
I have discovered conflicts with json versions in some projects using this gem. Using a frozen version of json can cause errors in Bundler with different dependencies of json and faraday.

In my particular example, i have problems with json (~> 1.7.7) in kickbox-ruby gem and json (1.8.1) in another one that bundler cannot resolve correctly.

Best Regards
