### PR TITLE
Lock down Faraday to ~> 0.8.8

### DIFF
--- a/kickbox.gemspec
+++ b/kickbox.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["lib/**/*"]
 
-  gem.add_dependency "faraday", ">= 0.8.8"
+  gem.add_dependency "faraday", "~> 0.8.8"
   gem.add_dependency "json", ">= 1.7.7"
 end


### PR DESCRIPTION
Faraday 0.9 changed stuff in the called env, meaning it breaks when trying to verify an email. `env[:response]` will be nil. 

it's basically the same issue encountered in VCR : https://github.com/vcr/vcr/issues/386

I've just reverted it to `~> 0.8.8` , like @samuelnp I had the issue with `json` which required some version flexibility but Faraday is fine being still on `0.8.x`. 
