### PR TITLE
expanded the read-me a little bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ client   = Kickbox::Client.new('Your_API_Key_Here')
 kickbox  = client.kickbox()
 response = kickbox.verify("test@example.com")
 ```
+`verify` returns a Kickbox::HttpClient::Response which has a `body` attribute which contains the deserialized JSON.
+
+You can use it like this:
+
+```ruby
+response.body['result'] #=> "deliverable"
+response.body['reason'] #=>  "accepted_email"
+
+```
+
+Full response information is provided below
+
+
 #### Options
 
 **timeout** `integer` (optional) - Maximum time, in milliseconds, for the API to complete a verification request. Default: 6000.


### PR DESCRIPTION
Playing around with the ruby client today and had to dig into the code to see how exactly to read the response object.

I wanted to make it clear that you can't simply call `response.result` and `response.reason`, and in fact there is a body hash that needs to be accessed.